### PR TITLE
Add windows jobs to CI Build Wheel workflow

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -81,7 +81,9 @@ jobs:
               cibuildwheel --print-build-identifiers --platform linux \
               | jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
               && cibuildwheel --print-build-identifiers --platform macos \
-              | jq -nRc '{"only": inputs, "os": "macos-latest"}'
+              | jq -nRc '{"only": inputs, "os": "macos-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform windows \
+              | jq -nRc '{"only": inputs, "os": "windows-2019"}'
             } | jq -sc
           )
           echo "include=$MATRIX"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -71,10 +71,6 @@ jobs:
         # Nb. keep cibuildwheel version pin consistent with job below
         run: pipx install cibuildwheel==2.16.5
       - id: set-matrix
-        # Once we have the windows build figured out, it can be added here
-        # by updating the matrix to include windows builds as well.
-        # See example here:
-        # https://github.com/lxml/lxml/blob/3ccc7d583e325ceb0ebdf8fc295bbb7fc8cd404d/.github/workflows/wheels.yml#L95C1-L106C51
         run: |
           MATRIX=$(
             {


### PR DESCRIPTION
@mxamin this adds the windows jobs back into the cibuildwheel workflow, so you can see how they are failing.

The blocker here for getting the windows builds to go green is that I don't know much about python builds on windows. I did take a quick look though the code in setup.py when I was doing the other CI updates, and it looks like the windows builds depend on some pre-build binaries from this repo: https://github.com/bgaifullin/libxml2-win-binaries. See [setup.py#L216](https://github.com/xmlsec/python-xmlsec/blob/d62c5b7f7600af739a66785fe9fae957e53ccda9/setup.py#L216).

This seems very similar to what lxml is doing for its windows builds: 
https://github.com/lxml/lxml/blob/a9f31d9ba0f6db7b0c6576b4b9014a4ea7649eca/buildlibxml.py#L29-L36

It seems like the repo with those binaries in it may need to be updated (and maybe moved into the xmlsec github org?) to get the windows builds working. 